### PR TITLE
Adding new source to the sender_map

### DIFF
--- a/config/Ipechelon.php
+++ b/config/Ipechelon.php
@@ -7,6 +7,7 @@ return [
         'report_file'   => '/^.*\.xml/i',
         'sender_map'    => [
             '/@ip-echelon.(com|us)/',
+            '/@copyright.ip-echelon.(com|us)/',
         ],
         'body_map'      => [
             //


### PR DESCRIPTION
Adds '/@copyright.ip-echelon.(com|us)/', to the sender_map to make this useful today.